### PR TITLE
Fix header logo comment

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -26,7 +26,7 @@ export default function Header() {
     <Box component="header" className={classes.header}>
       <Container size="xl" h="100%" py={0}>
         <Group justify="space-between" h="100%">
-          {/* ✅ Logo wrapped in Next.js Link with no nested <a> */}
+          {/* Logo wrapped in Mantine Anchor */}
           <Anchor href="/">
             <Group gap="xs">
               <Box w={100} h={100}>


### PR DESCRIPTION
## Summary
- clarify how the header logo is wrapped

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684464fa8fac83339d4bfa06e1841d6a