### PR TITLE
Align password verification iterations

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -11,7 +11,8 @@ function verifyPassword(
 ): boolean {
   const [salt, hash] = storedPassword.split(':');
   const suppliedHash = crypto
-    .pbkdf2Sync(suppliedPassword, salt, 1000, 64, 'sha512')
+    // Match the 100000 iterations used when creating accounts
+    .pbkdf2Sync(suppliedPassword, salt, 100000, 64, 'sha512')
     .toString('hex');
   return hash === suppliedHash;
 }

--- a/scripts/create-admin.ts
+++ b/scripts/create-admin.ts
@@ -145,7 +145,7 @@ async function promptQuestion(
 function hashPassword(password: string): string {
   const salt = crypto.randomBytes(32).toString('hex');
   const hash = crypto
-    .pbkdf2Sync(password, salt, 100000, 64, 'sha512') // Increased iterations
+    .pbkdf2Sync(password, salt, 100000, 64, 'sha512') // 100000 iterations
     .toString('hex');
   return `${salt}:${hash}`;
 }


### PR DESCRIPTION
## Summary
- update NextAuth password verification to use 100k iterations
- clarify comment in admin creation script about iteration count

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684460589bac8333978889604c5b4d5b